### PR TITLE
remove mysqld facility

### DIFF
--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -43,7 +43,7 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 
 # Log anything (except mail) of level info or higher.
 # Don't log private authentication messages!
-*.info;mail.none;authpriv.none;cron.none;mysqld.none    /var/log/messages
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
 
 # The authpriv file has restricted access.
 authpriv.*                                              /var/log/secure

--- a/templates/xtradb.conf.j2
+++ b/templates/xtradb.conf.j2
@@ -1,5 +1,0 @@
-$InputFileName /var/lib/mysql/slow.log
-$InputFileTag mysqld:
-$InputFileStateFile mysqld
-$InputRunFileMonitor
-$InputFileFacility mysqld


### PR DESCRIPTION
The `mysqld.none` facility is not needed when provisioning without MySQL.

```
rsyslogd-3000:  unknown facility name "mysqld" [try http://www.rsyslog.com/e/3000 ] 
rsyslogd:  the last error occured in /etc/rsyslog.conf, line 46:"*.info;mail.none;authpriv.none;cron.none;mysqld.none    /var/log/messages" 
rsyslogd:  warning: selector line without actions will be discarded 
rsyslogd-2124:  CONFIG ERROR: could not interpret master config file '/etc/rsyslog.conf'. [try http://www.rsyslog.com/e/2124 ] 
```
