### PR TITLE
add tls support to papertrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ useful when the `logstash_forwarder` have multiple IPs, such as global and priva
 
 If `logstash_syslog_port` is set, rsyslog will send to the `logstash_forwarder` on that port.
 The default port is `514`. This is useful if logstash is not running as root and cannot listen on ports 0-1024.
+
+If you are not using a centralized log forwarding service and would like to have rsyslog on each server to
+send logs directly to [Papertrail](https://papertrailapp.com/), set the following:
+  - set `use_papertrail` to `true`. Default is false.
+  - set `papertrail_host` to the [Papertrail log destination](https://papertrailapp.com/account/destinations). An
+    account is required.
+  - set `papertrail_port` to the [Papertrail port](https://papertrailapp.com/account/destinations) given.
+  - `logstash_forwarder` defaults to an empty string, `''`. If it is defined, `rsyslog` will forward the logs to this machine.
+  - set `papertrail_pem` to the full path of the papertrail-bundle.pem file. Default: `/etc/papertrail-bundle.pem`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+use_papertrail: false
+papertrail_bundle: /etc/papertrail-bundle.pem
+logstash_forwarder: ''
+papertrail_pem_checksum: ba3b40a34ec33ac0869fa5b17a0c80fc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,9 +24,16 @@
     regexp="^\*\.\* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
     line="*.* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
     state=present
-  when: rsyslog_conf.stat.exists|bool and logstash_forwarder is defined
+  when: rsyslog_conf.stat.exists|bool and logstash_forwarder != ''
   notify:
     - Restart rsyslog
+  tags:
+    - rsyslog
+    - files
+
+- name: "Set Papertrail"
+  include: papertrail.yml
+  when: use_papertrail|bool and logstash_forwarder == ''
   tags:
     - rsyslog
     - files

--- a/tasks/papertrail.yml
+++ b/tasks/papertrail.yml
@@ -1,0 +1,90 @@
+- name: "Install rsyslog-gnutls (CentOS)"
+  yum:
+    name: "rsyslog-gnutls"
+    state: present
+  when: use_papertrail|bool and ansible_distribution == 'CentOS'
+  tags:
+    - rsyslog
+    - files
+
+- name: "Install rsyslog-gnutls (Debian)"
+  apt:
+    name: "rsyslog-gnutls"
+    state: present
+  when: use_papertrail|bool and (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
+  tags:
+    - rsyslog
+    - files
+
+- name: "Install rsyslog-gnutls (Ubuntu) 1 of 2 - Add ppa:adiscon/v8-stable"
+  apt_repository:
+    repo: "ppa:adiscon/v8-stable"
+    state: present
+  when: use_papertrail|bool and ansible_distribution == 'Ubuntu'
+  tags:
+    - rsyslog
+    - files
+
+- name: "Install rsyslog-gnutls (Ubuntu) 1 of 2"
+  apt:
+    name: "rsyslog"
+    state: present
+  when: use_papertrail|bool and ansible_distribution == 'Ubuntu'
+  tags:
+    - rsyslog
+    - files
+
+- name: "Papertrail - Download papertrail-bundle.pem"
+  get_url: >
+    url='https://papertrailapp.com/tools/papertrail-bundle.pem'
+    dest="{{ papertrail_pem }}"
+    mode=0444
+  when: use_papertrail|bool and logstash_forwarder == ''
+  notify:
+    - "Restart rsyslog"
+  tags:
+    - rsyslog
+    - files
+
+- name: 'Papertrail - Get md5sum of papertrail-bundle.pem'
+  shell: md5sum {{ papertrail_pem }} | cut -f 1 -d " "
+  register: papertrailmd5
+  when: use_papertrail|bool and logstash_forwarder == ''
+  tags:
+    - rsyslog
+    - files
+
+- name: 'Papertrail - Verify checksum of papertrail-bundle.pem'
+  fail:
+    msg: "Checksum of {{ papertrail_pem }} does not match the checksum of the Papertrail bundle"
+  when: use_papertrail|bool and logstash_forwarder == '' and papertrailmd5.stdout != papertrail_pem_checksum
+  tags:
+    - rsyslog
+    - files
+
+- name: "Upload /etc/rsyslog.d/papertrail.conf"
+  template: >
+    dest=/etc/rsyslog.d/papertrail.conf
+    src="papertrail.conf.j2"
+    owner: root
+    group: root
+    mode: 0644
+  when: use_papertrail|bool and logstash_forwarder == '' and rsyslog_conf.stat.exists|bool
+  notify:
+    - "Restart rsyslog"
+  tags:
+    - rsyslog
+    - files
+
+- name: "Set forwarding (with TLS) in /etc/rsyslog.conf. 6"
+  lineinfile: >
+    dest=/etc/rsyslog.conf
+    regexp="^\*\.\* @@{{ papertrail_host }}:{{ papertrail_port }}"
+    line="*.* @@{{ papertrail_host }}:{{ papertrail_port }}"
+    state=present
+  when: use_papertrail|bool and logstash_forwarder == '' and rsyslog_conf.stat.exists|bool
+  notify:
+    - "Restart rsyslog"
+  tags:
+    - rsyslog
+    - files

--- a/templates/papertrail.conf.j2
+++ b/templates/papertrail.conf.j2
@@ -1,0 +1,5 @@
+$DefaultNetstreamDriverCAFile {{ papertrail_pem }} # trust these CAs
+$ActionSendStreamDriver gtls # use gtls netstream driver
+$ActionSendStreamDriverMode 1 # require TLS
+$ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
+$ActionSendStreamDriverPermittedPeer *.papertrailapp.com


### PR DESCRIPTION
Base on [Papertrail's instructions](http://help.papertrailapp.com/kb/configuration/encrypting-remote-syslog-with-tls-ssl/#rsyslog).

New variable: `use_papertrail`. Defaults to false.
If set to `true`, also define `papertrail_host`, `papertrail_port`.
`logstash_forwarder` is defaulted to an empty string, `''`.