### PR TITLE
option to listen on UDP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ You role must contain a template file named `rsyslog.j2` which will be copied on
 Variables
 ---------
 
+When `use_rsyslog_udp` is set to `true`, rsyslog will provides UDP syslog reception. Default is `false`.
+The default UDP listening port is `514`. Set `use_rsyslog_udp_port` to change the port.
+
+
 If `logstash_forwarder` is set to the name of one of the machine in the inventory,
 `rsyslog` will forward the logs to this machine.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,6 @@ use_papertrail: false
 papertrail_bundle: /etc/papertrail-bundle.pem
 logstash_forwarder: ''
 papertrail_pem_checksum: ba3b40a34ec33ac0869fa5b17a0c80fc
+
+use_rsyslog_udp: false
+use_rsyslog_udp_port: 514

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,31 @@
     - rsyslog
     - files
 
+- name: "Set rsyslog to listen on UDP"
+  template: >
+    src=00_udp_server.conf.j2
+    dest=/etc/rsyslog.d/00_udp_server.conf
+    mode=0644
+    owner=root
+    group=root
+  when: use_rsyslog_udp|bool and rsyslog_conf.stat.exists|bool
+  notify:
+    - Restart rsyslog
+  tags:
+    - rsyslog
+    - files
+
+- name: "Set rsyslog to not listen on UDP"
+  file: >
+    dest=/etc/rsyslog.d/00_udp_server.conf
+    state=absent
+  when: not use_rsyslog_udp|bool and rsyslog_conf.stat.exists|bool
+  notify:
+    - Restart rsyslog
+  tags:
+    - rsyslog
+    - files
+
 - name: "Set forwarding to logstash"
   lineinfile: >
     dest=/etc/rsyslog.conf

--- a/templates/00_udp_server.conf.j2
+++ b/templates/00_udp_server.conf.j2
@@ -1,0 +1,2 @@
+$ModLoad imudp
+$UDPServerRun {{ use_rsyslog_udp_port }}


### PR DESCRIPTION
When rsyslogd gets installed, the default setting is commented out, so UDP reception is off by default.

This PR allows to turn it on.

New variables:

  - `use_rsyslog_udp` (default: `false`), set to `true` so that rsyslogd will listen on UDP.
  - `use_rsyslog_udp_port` (default: `514`), sets the UDP port to listen on.
