### PR TITLE
Update yaml syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The default UDP listening port is `514`. Set `use_rsyslog_udp_port` to change th
 If `logstash_forwarder` is set to the name of one of the machine in the inventory,
 `rsyslog` will forward the logs to this machine.
 
-In addition to setting `logstash_forward`, if `private_ip` is set, `rsyslog` will forward 
-to this IP address. Default is the `ansible_ssh_host` of the `logstash_forwarder`. This is
+In addition to setting `logstash_forward`, if `private_ip` is set, `rsyslog` will forward
+to this IP address. Default is the `ansible_host` of the `logstash_forwarder`. This is
 useful when the `logstash_forwarder` have multiple IPs, such as global and private IPs.
 
 If `logstash_syslog_port` is set, rsyslog will send to the `logstash_forwarder` on that port.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In your role's meta, add a dependency to this role using the syntax described be
 # my_role/meta/main.yml
 dependencies:
   - role: aerisloud.rsyslog
-    role_name: my_role
+    caller_name: my_role
 ```
 
 You role must contain a template file named `rsyslog.j2` which will be copied on the server.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 use_papertrail: false
-papertrail_bundle: /etc/papertrail-bundle.pem
+papertrail_pem: /etc/papertrail-bundle.pem
 logstash_forwarder: ''
 papertrail_pem_checksum: ba3b40a34ec33ac0869fa5b17a0c80fc
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,11 @@
     - files
 
 - name: "Set PreserverFQDN on"
-  lineinfile: >
-    dest=/etc/rsyslog.conf
-    regexp='^\$PreserveFQDN'
-    line='$PreserveFQDN on'
-    state=present
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    regexp: '^\$PreserveFQDN'
+    line: '$PreserveFQDN on'
+    state: present
   when: rsyslog_conf.stat.exists|bool
   notify:
     - Restart rsyslog
@@ -19,12 +19,12 @@
     - files
 
 - name: "Set rsyslog to listen on UDP"
-  template: >
-    src=00_udp_server.conf.j2
-    dest=/etc/rsyslog.d/00_udp_server.conf
-    mode=0644
-    owner=root
-    group=root
+  template:
+    src: 00_udp_server.conf.j2
+    dest: /etc/rsyslog.d/00_udp_server.conf
+    mode: 0644
+    owner: root
+    group: root
   when: use_rsyslog_udp|bool and rsyslog_conf.stat.exists|bool
   notify:
     - Restart rsyslog
@@ -33,9 +33,9 @@
     - files
 
 - name: "Set rsyslog to not listen on UDP"
-  file: >
-    dest=/etc/rsyslog.d/00_udp_server.conf
-    state=absent
+  file:
+    dest: /etc/rsyslog.d/00_udp_server.conf
+    state: absent
   when: not use_rsyslog_udp|bool and rsyslog_conf.stat.exists|bool
   notify:
     - Restart rsyslog
@@ -44,11 +44,11 @@
     - files
 
 - name: "Set forwarding to logstash"
-  lineinfile: >
-    dest=/etc/rsyslog.conf
-    regexp="^\*\.\* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
-    line="*.* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
-    state=present
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    regexp: '^\*\.\* @{{ hostvars[logstash_forwarder]["private_ip"]|default(hostvars[logstash_forwarder]["ansible_ssh_host"]) }}:{{ logstash_syslog_port|default("514") }}'
+    line: "*.* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
+    state: present
   when: rsyslog_conf.stat.exists|bool and logstash_forwarder != ''
   notify:
     - Restart rsyslog
@@ -64,13 +64,13 @@
     - files
 
 - name: "Configure rsyslog for {{ role_name }}"
-  template: >
-    src=../../{{ role_name }}/templates/rsyslog.j2
-    dest=/etc/rsyslog.d/{{ role_name }}.conf
-    mode=0644
-    owner=root
-    group=root
-    backup=yes
+  template:
+    src: "../../{{ role_name }}/templates/rsyslog.j2"
+    dest: "/etc/rsyslog.d/{{ role_name }}.conf"
+    mode: 0644
+    owner: root
+    group: root
+    backup: yes
   notify:
     - Restart rsyslog
   when: rsyslog_conf.stat.exists|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,8 +46,8 @@
 - name: "Set forwarding to logstash"
   lineinfile:
     dest: /etc/rsyslog.conf
-    regexp: '^\*\.\* @{{ hostvars[logstash_forwarder]["private_ip"]|default(hostvars[logstash_forwarder]["ansible_ssh_host"]) }}:{{ logstash_syslog_port|default("514") }}'
-    line: "*.* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_ssh_host']) }}:{{ logstash_syslog_port|default('514') }}"
+    regexp: '^\*\.\* @{{ hostvars[logstash_forwarder]["private_ip"]|default(hostvars[logstash_forwarder]["ansible_host"]) }}:{{ logstash_syslog_port|default("514") }}'
+    line: "*.* @{{ hostvars[logstash_forwarder]['private_ip']|default(hostvars[logstash_forwarder]['ansible_host']) }}:{{ logstash_syslog_port|default('514') }}"
     state: present
   when: rsyslog_conf.stat.exists|bool and logstash_forwarder != ''
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,10 +31,10 @@
     - rsyslog
     - files
 
-- name: "Configure rsyslog for {{ role_name }}"
+- name: "Configure rsyslog for {{ caller_name }}"
   template: >
-    src=../../{{ role_name }}/templates/rsyslog.j2
-    dest=/etc/rsyslog.d/{{ role_name }}.conf
+    src=roles/{{ caller_name }}/templates/rsyslog.conf.j2
+    dest=/etc/rsyslog.d/{{ caller_name }}.conf
     mode=0644
     owner=root
     group=root

--- a/tasks/papertrail.yml
+++ b/tasks/papertrail.yml
@@ -35,10 +35,10 @@
     - files
 
 - name: "Papertrail - Download papertrail-bundle.pem"
-  get_url: >
-    url='https://papertrailapp.com/tools/papertrail-bundle.pem'
-    dest="{{ papertrail_pem }}"
-    mode=0444
+  get_url:
+    url: 'https://papertrailapp.com/tools/papertrail-bundle.pem'
+    dest: "{{ papertrail_pem }}"
+    mode: 0444
   when: use_papertrail|bool and logstash_forwarder == ''
   notify:
     - "Restart rsyslog"
@@ -63,9 +63,9 @@
     - files
 
 - name: "Upload /etc/rsyslog.d/papertrail.conf"
-  template: >
-    dest=/etc/rsyslog.d/papertrail.conf
-    src="papertrail.conf.j2"
+  template:
+    dest: /etc/rsyslog.d/papertrail.conf
+    src: "papertrail.conf.j2"
     owner: root
     group: root
     mode: 0644
@@ -77,11 +77,11 @@
     - files
 
 - name: "Set forwarding (with TLS) in /etc/rsyslog.conf. 6"
-  lineinfile: >
-    dest=/etc/rsyslog.conf
-    regexp="^\*\.\* @@{{ papertrail_host }}:{{ papertrail_port }}"
-    line="*.* @@{{ papertrail_host }}:{{ papertrail_port }}"
-    state=present
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    regexp: '^\*\.\* @@{{ papertrail_host }}:{{ papertrail_port }}'
+    line: "*.* @@{{ papertrail_host }}:{{ papertrail_port }}"
+    state: present
   when: use_papertrail|bool and logstash_forwarder == '' and rsyslog_conf.stat.exists|bool
   notify:
     - "Restart rsyslog"


### PR DESCRIPTION
 - yaml syntax updated.
 - fix Papertrail variable name
 - [deprecated `ansible_ssh_host` and replaced with `ansible_host`](http://docs.ansible.com/ansible/intro_inventory.html#list-of-behavioral-inventory-parameters)
 - incorporated fix from https://github.com/AerisCloud/ansible-rsyslog/pull/8  (works with Ansible 2.3.1)